### PR TITLE
fix(scanner): preserve accounting under partial flushes and rescans

### DIFF
--- a/tests/test_end_to_end_totals.py
+++ b/tests/test_end_to_end_totals.py
@@ -1,0 +1,132 @@
+"""End-to-end accounting invariant: JSONL on disk → overview_totals numbers.
+
+This is the one test the suite was missing — it wires a hand-computed fixture
+all the way through the real ``scan_dir`` pipeline and asserts every
+token-bucket SUM matches. Previously, a scanner regression that silently
+dropped or double-counted tokens could pass CI because no test checked
+token totals against known-good values.
+"""
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from token_dashboard.db import init_db, overview_totals
+from token_dashboard.scanner import scan_dir
+
+
+def _user(uuid: str, ts: str, text: str) -> dict:
+    return {
+        "type": "user", "uuid": uuid, "sessionId": "s1",
+        "timestamp": ts, "isSidechain": False,
+        "message": {"role": "user", "content": text},
+    }
+
+
+def _assistant(uuid: str, parent: str, msg_id: str, ts: str, usage: dict,
+               tool_uses=None) -> dict:
+    content = [{"type": "text", "text": "..."}]
+    if tool_uses:
+        content.extend(tool_uses)
+    return {
+        "type": "assistant", "uuid": uuid, "parentUuid": parent,
+        "sessionId": "s1", "timestamp": ts, "isSidechain": False,
+        "message": {
+            "id": msg_id,
+            "model": "claude-opus-4-7",
+            "content": content,
+            "usage": usage,
+        },
+    }
+
+
+def _usage(inp: int, out: int, cr: int, c5: int, c1: int) -> dict:
+    return {
+        "input_tokens": inp,
+        "output_tokens": out,
+        "cache_read_input_tokens": cr,
+        "cache_creation": {
+            "ephemeral_5m_input_tokens": c5,
+            "ephemeral_1h_input_tokens": c1,
+        },
+    }
+
+
+class EndToEndTotalsTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.db = os.path.join(self.tmp, "t.db")
+        self.proj_root = os.path.join(self.tmp, "projects")
+        self.proj_dir = os.path.join(self.proj_root, "C--work-sample")
+        os.makedirs(self.proj_dir)
+        init_db(self.db)
+
+    def test_scan_totals_match_hand_computed_sums(self):
+        """Fixture covers: dedup of streaming snapshots (msg_A), a tool_use
+        record (msg_B), and a plain assistant record (msg_C). Every
+        token-bucket SUM in overview_totals must equal the hand-computed
+        value after only the final snapshot of msg_A survives dedup."""
+        records = [
+            # --- Turn 1 ---
+            _user("u1", "2026-04-10T00:00:00Z", "prompt 1"),
+            # Streaming partial for msg_A — must be evicted by the final.
+            _assistant("a1", "u1", "msg_A", "2026-04-10T00:00:01Z",
+                       _usage(inp=100, out=10,  cr=500, c5=200, c1=0)),
+            # Final snapshot for msg_A — this one is what billing saw.
+            _assistant("a2", "u1", "msg_A", "2026-04-10T00:00:02Z",
+                       _usage(inp=100, out=200, cr=500, c5=200, c1=50)),
+
+            # --- Turn 2 ---
+            _user("u2", "2026-04-10T00:01:00Z", "prompt 2"),
+            # Assistant with a tool_use block (contributes 1 row to tool_calls).
+            _assistant("a3", "u2", "msg_B", "2026-04-10T00:01:01Z",
+                       _usage(inp=50, out=80, cr=300, c5=0, c1=100),
+                       tool_uses=[{
+                           "type": "tool_use", "id": "tu1", "name": "Read",
+                           "input": {"file_path": "foo.py"},
+                       }]),
+            # Plain assistant reply.
+            _assistant("a4", "u2", "msg_C", "2026-04-10T00:01:02Z",
+                       _usage(inp=60, out=120, cr=350, c5=30, c1=0)),
+        ]
+
+        path = os.path.join(self.proj_dir, "s1.jsonl")
+        with open(path, "w", encoding="utf-8") as f:
+            for r in records:
+                f.write(json.dumps(r) + "\n")
+
+        scan_dir(self.proj_root, self.db)
+
+        totals = overview_totals(self.db)
+
+        # Hand-computed (a1 evicted; a2 + a3 + a4 survive):
+        # input  = 100 + 50 + 60   = 210
+        # output = 200 + 80 + 120  = 400
+        # cache_read      = 500 + 300 + 350 = 1150
+        # cache_create_5m = 200 +   0 +  30 =  230
+        # cache_create_1h =  50 + 100 +   0 =  150
+        self.assertEqual(totals["sessions"], 1)
+        self.assertEqual(totals["turns"], 2, "two user prompts in this fixture")
+        self.assertEqual(totals["input_tokens"], 210)
+        self.assertEqual(totals["output_tokens"], 400)
+        self.assertEqual(totals["cache_read_tokens"], 1150)
+        self.assertEqual(totals["cache_create_5m_tokens"], 230)
+        self.assertEqual(totals["cache_create_1h_tokens"], 150)
+
+        # Dedup invariant: only 3 assistant rows survive (a1 evicted).
+        with sqlite3.connect(self.db) as c:
+            assistant_uuids = sorted(
+                r[0] for r in c.execute(
+                    "SELECT uuid FROM messages WHERE type='assistant'"
+                )
+            )
+            tool_count = c.execute(
+                "SELECT COUNT(*) FROM tool_calls WHERE tool_name='Read'"
+            ).fetchone()[0]
+        self.assertEqual(assistant_uuids, ["a2", "a3", "a4"])
+        self.assertEqual(tool_count, 1, "single tool_use row in fixture")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scanner_rescan.py
+++ b/tests/test_scanner_rescan.py
@@ -1,0 +1,143 @@
+"""Re-scanning a JSONL file must not duplicate or lose rows.
+
+When Claude Code writes the same `.jsonl` in place (log compaction, crash
+recovery, or simply a touched mtime with the same content), the scanner
+falls through to a full rescan from offset 0. Messages use INSERT OR REPLACE
+on uuid so those rows stay correct, but tool_calls has no unique key and
+INSERTs blindly — so every rescan inflates tool counts.
+"""
+import json
+import os
+import sqlite3
+import tempfile
+import time
+import unittest
+
+from token_dashboard.db import init_db
+from token_dashboard.scanner import scan_dir
+
+
+def _assistant_with_tool_use(uuid: str, msg_id: str, ts: str, output_tokens: int) -> dict:
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "parentUuid": "u1",
+        "sessionId": "s1",
+        "timestamp": ts,
+        "isSidechain": False,
+        "message": {
+            "id": msg_id,
+            "model": "claude-opus-4-7",
+            "content": [
+                {"type": "tool_use", "id": "tu1", "name": "Read",
+                 "input": {"file_path": "foo.py"}},
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": output_tokens},
+        },
+    }
+
+
+def _user_record() -> dict:
+    return {
+        "type": "user", "uuid": "u1", "sessionId": "s1",
+        "timestamp": "2026-04-10T00:00:00Z", "isSidechain": False,
+        "message": {"role": "user", "content": "hi"},
+    }
+
+
+def _write_jsonl(path: str, records) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+class RescanIdempotencyTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.db = os.path.join(self.tmp, "t.db")
+        self.proj_root = os.path.join(self.tmp, "projects")
+        self.proj_dir = os.path.join(self.proj_root, "C--work-sample")
+        os.makedirs(self.proj_dir)
+        init_db(self.db)
+
+    def _jsonl_path(self) -> str:
+        return os.path.join(self.proj_dir, "s1.jsonl")
+
+    def _count_tools(self) -> int:
+        with sqlite3.connect(self.db) as c:
+            return c.execute(
+                "SELECT COUNT(*) FROM tool_calls WHERE tool_name='Read'"
+            ).fetchone()[0]
+
+    def test_partial_line_at_eof_is_not_skipped_on_next_scan(self):
+        """A record mid-flush (no trailing newline yet) must be picked up
+        on the next scan once the line completes — we cannot advance the
+        byte offset past a line we haven't successfully parsed."""
+        path = self._jsonl_path()
+
+        # Scan 1: complete record A, then a partial line for record B with no
+        # trailing newline (simulating Claude Code mid-flush).
+        rec_a = _assistant_with_tool_use("a1", "msg_A", "2026-04-10T00:00:01Z", 10)
+        partial_b = json.dumps(
+            _assistant_with_tool_use("a2", "msg_B", "2026-04-10T00:00:02Z", 20)
+        )
+        half = len(partial_b) // 2
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(json.dumps(_user_record()) + "\n")
+            f.write(json.dumps(rec_a) + "\n")
+            f.write(partial_b[:half])  # truncated, no "\n"
+
+        scan_dir(self.proj_root, self.db)
+
+        with sqlite3.connect(self.db) as c:
+            uuids_after_scan1 = sorted(
+                r[0] for r in c.execute("SELECT uuid FROM messages")
+            )
+        self.assertEqual(
+            uuids_after_scan1, ["a1", "u1"],
+            "partial line must be skipped on first scan (JSON decode fails)",
+        )
+
+        # Scan 2: complete record B's line + append a brand-new record C.
+        rec_c = _assistant_with_tool_use("a3", "msg_C", "2026-04-10T00:00:03Z", 30)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(partial_b[half:] + "\n")
+            f.write(json.dumps(rec_c) + "\n")
+        future = time.time() + 10
+        os.utime(path, (future, future))
+
+        scan_dir(self.proj_root, self.db)
+
+        with sqlite3.connect(self.db) as c:
+            uuids_after_scan2 = sorted(
+                r[0] for r in c.execute("SELECT uuid FROM messages")
+            )
+        self.assertEqual(
+            uuids_after_scan2, ["a1", "a2", "a3", "u1"],
+            "record whose line was partial on scan 1 must be loaded on scan 2",
+        )
+
+    def test_rescan_with_same_content_does_not_duplicate_tool_calls(self):
+        """Full rescan (mtime changed, content unchanged) must not grow tool_calls."""
+        _write_jsonl(self._jsonl_path(), [
+            _user_record(),
+            _assistant_with_tool_use("a1", "msg_X", "2026-04-10T00:00:01Z", 42),
+        ])
+
+        scan_dir(self.proj_root, self.db)
+        self.assertEqual(self._count_tools(), 1, "first scan inserts one tool_call")
+
+        # Force mtime to move forward without changing content — triggers a
+        # full rescan from offset 0 (the scan_dir "else" branch).
+        future = time.time() + 10
+        os.utime(self._jsonl_path(), (future, future))
+
+        scan_dir(self.proj_root, self.db)
+        self.assertEqual(
+            self._count_tools(), 1,
+            "rescan must not duplicate tool_calls — INSERT needs to clear per-message first",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scanner_walk.py
+++ b/tests/test_scanner_walk.py
@@ -41,7 +41,7 @@ class WalkTests(unittest.TestCase):
         scan_dir(self.proj_root, self.db)
         path = os.path.join(self.proj_root, "C--work-sample", "s1.jsonl")
         with open(path, "a", encoding="utf-8") as f:
-            f.write('\n{"type":"assistant","uuid":"a2","sessionId":"s1","timestamp":"2026-04-10T00:00:03Z","isSidechain":false,"message":{"model":"claude-haiku-4-5","usage":{"input_tokens":1,"output_tokens":1}}}')
+            f.write('{"type":"assistant","uuid":"a2","sessionId":"s1","timestamp":"2026-04-10T00:00:03Z","isSidechain":false,"message":{"model":"claude-haiku-4-5","usage":{"input_tokens":1,"output_tokens":1}}}\n')
         n2 = scan_dir(self.proj_root, self.db)
         self.assertEqual(n2["messages"], 1)
 

--- a/token_dashboard/scanner.py
+++ b/token_dashboard/scanner.py
@@ -185,34 +185,61 @@ def _evict_prior_snapshots(conn, session_id: str, message_id: str, keep_uuid: st
 
 
 def scan_file(path: Path, project_slug: str, conn, start_byte: int = 0) -> dict:
+    """Ingest new lines from a JSONL file starting at ``start_byte``.
+
+    Returns message/tool counts plus ``end_offset`` — the byte offset just
+    past the last fully-parsed line. Callers persist ``end_offset`` as the
+    file's high-water mark so a line partially flushed at EOF gets re-read
+    once it completes.
+    """
     msgs = tools = 0
+    end_offset = start_byte
     with open(path, "rb") as fb:
         if start_byte:
             fb.seek(start_byte)
-        for raw in fb:
+        while True:
+            raw = fb.readline()
+            if not raw:
+                break  # EOF
+            if not raw.endswith(b"\n"):
+                # Partial line — Claude Code is mid-flush. Leave the
+                # high-water mark behind the line start so we re-read it
+                # once the write completes.
+                break
+            line_end = fb.tell()
             try:
                 line = raw.decode("utf-8", errors="replace").strip()
             except Exception:
+                end_offset = line_end
                 continue
             if not line:
+                end_offset = line_end
                 continue
             try:
                 rec = json.loads(line)
             except json.JSONDecodeError:
+                end_offset = line_end
                 continue
             if not isinstance(rec, dict) or "uuid" not in rec or "type" not in rec:
+                end_offset = line_end
                 continue
             msg, tlist = parse_record(rec, project_slug)
             if not msg["session_id"] or not msg["timestamp"]:
+                end_offset = line_end
                 continue
             if msg["message_id"]:
                 _evict_prior_snapshots(conn, msg["session_id"], msg["message_id"], msg["uuid"])
             conn.execute(INSERT_MSG, msg)
+            # tool_calls has no natural unique key; clear any prior rows for
+            # this uuid so full rescans stay idempotent instead of
+            # duplicating rows.
+            conn.execute("DELETE FROM tool_calls WHERE message_uuid=?", (msg["uuid"],))
             for t in tlist:
                 conn.execute(INSERT_TOOL, t)
                 tools += 1
             msgs += 1
-    return {"messages": msgs, "tools": tools}
+            end_offset = line_end
+    return {"messages": msgs, "tools": tools, "end_offset": end_offset}
 
 
 def scan_dir(projects_root: Union[str, Path], db_path: Union[str, Path]) -> dict:
@@ -236,9 +263,12 @@ def scan_dir(projects_root: Union[str, Path], db_path: Union[str, Path]) -> dict
                 offset = row["bytes_read"]
             slug = _project_slug(p, root)
             sub = scan_file(p, slug, conn, start_byte=offset)
+            # Persist the byte offset of the last fully-parsed line (not
+            # st_size) so a partial line mid-flush is retried on the next
+            # scan instead of being skipped over.
             conn.execute(
                 "INSERT OR REPLACE INTO files (path, mtime, bytes_read, scanned_at) VALUES (?, ?, ?, ?)",
-                (str(p), stat.st_mtime, stat.st_size, time.time()),
+                (str(p), stat.st_mtime, sub["end_offset"], time.time()),
             )
             totals["messages"] += sub["messages"]
             totals["tools"]    += sub["tools"]


### PR DESCRIPTION
## Summary

Two silent-accounting bugs on the JSONL → DB path, surfaced by code review. Students cloning `main` currently get a working dashboard with quiet inaccuracies; this PR fixes that.

- **Partial-line EOF (C1)** — `scan_file` iterated Python's file iterator and persisted `stat.st_size` as `bytes_read`, so any line mid-flush when Claude Code was still writing got skipped, and its completed form was never re-read. Now uses `readline()` and persists `end_offset` (the byte past the last `\n`-terminated line). Partial lines retry on the next scan.
- **tool_calls duplication (C3)** — full rescans (mtime changed, content same) re-inserted `tool_calls` rows because INSERT had no natural unique key. Added a per-message `DELETE` before `INSERT` so rescans stay idempotent.

Also adds two tests locking the accounting invariants:
- `tests/test_scanner_rescan.py` — direct coverage of both bugs.
- `tests/test_end_to_end_totals.py` — runs a hand-computed fixture through `scan_dir` and asserts every bucket in `overview_totals` matches. The test the suite was missing.

And a latent-bug fix in `test_rescan_picks_up_appended_lines` that appended a line without a trailing newline — the newly strict scanner correctly rejected it, revealing the test was wrong (real JSONL lines are always `\n`-terminated).

## Test plan

- [x] `python3 -m unittest discover tests` → 71 tests pass (was 68)
- [x] Dashboard starts cleanly against real `~/.claude/projects/` data
- [x] Tools/Skills charts no longer inflate after a file gets touched
- [ ] Reviewer to confirm `end_offset` semantics match expected behavior on truncation + append scenarios

## Known follow-ups (not in this PR)

- **C2** (truncation leaves stale rows) — needs a schema change (`messages.source_file`) to fix cleanly
- **I1** (`cache_creation_input_tokens` scalar fallback missing) — doesn't fire on current transcripts but could regress
- **I2** (`/api/scan` vs background-loop race) — cosmetic, doesn't corrupt data
- **I4** (tokens semantics differ across tabs) — display inconsistency only