### PR TITLE
Add Claude Code session initialization hooks

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code remote (web) sessions
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Verify Python 3.8+ is available
+python3 -c "
+import sys
+if sys.version_info < (3, 8):
+    print('ERROR: Python 3.8+ required, found', sys.version)
+    sys.exit(1)
+print('Python', sys.version, 'OK')
+"
+
+# Make the project importable without install
+echo "export PYTHONPATH=\"${CLAUDE_PROJECT_DIR}:${PYTHONPATH:-}\"" >> "$CLAUDE_ENV_FILE"
+
+echo "Token Dashboard environment ready."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ out/
 node_modules/
 *.db
 .superpowers/
-.claude/
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/hooks/**
 docs/superpowers/


### PR DESCRIPTION
## Summary
This PR adds Claude Code remote session initialization configuration to set up the development environment automatically when working in Claude Code web sessions.

## Key Changes
- **Added `.claude/hooks/session-start.sh`**: A bash script that runs at the start of Claude Code remote sessions to:
  - Verify Python 3.8+ is available
  - Configure the project directory in the Python path for importability without installation
  - Display a readiness message
  
- **Added `.claude/settings.json`**: Configuration file that registers the session-start hook to execute automatically in Claude Code remote environments

- **Updated `.gitignore`**: Modified to track the new `.claude/` configuration files while keeping other `.claude/` artifacts ignored:
  - Allows `settings.json` and the `hooks/` directory to be version controlled
  - Maintains exclusion of other `.claude/` files (like superpowers cache)

## Implementation Details
- The session-start hook only executes in Claude Code remote (web) sessions via the `CLAUDE_CODE_REMOTE` environment variable check
- Python version validation ensures compatibility before proceeding
- Uses `CLAUDE_PROJECT_DIR` and `CLAUDE_ENV_FILE` environment variables provided by Claude Code for proper path configuration

https://claude.ai/code/session_01VZv6n45Asz1G5ZR68Gc6JR