### PR TITLE
feat(skills): include project-local .claude/skills/ in the catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Inspired by [phuryn/claude-usage](https://github.com/phuryn/claude-usage) but di
 
 ## Status
 
-Working codebase. 68 Python unit tests (`python3 -m unittest discover tests`). Seven UI tabs wired up (Overview, Prompts, Sessions, Projects, Skills, Tips, Settings). Runs on macOS, Windows, and Linux.
+Working codebase. 75 Python unit tests (`python3 -m unittest discover tests`). Seven UI tabs wired up (Overview, Prompts, Sessions, Projects, Skills, Tips, Settings). Runs on macOS, Windows, and Linux.
 
 ## Architecture
 
@@ -36,7 +36,7 @@ Env vars: `PORT` (default 8080), `HOST` (default 127.0.0.1), `CLAUDE_PROJECTS_DI
 
 ## Known limitations
 
-See `docs/KNOWN_LIMITATIONS.md`. Current summary: Skills `tokens_per_call` is populated only for skills installed under the three scanned roots (`~/.claude/skills/`, `~/.claude/scheduled-tasks/`, `~/.claude/plugins/`); project-local skills and subagent-dispatched skills show invocation counts but blank token counts.
+See `docs/KNOWN_LIMITATIONS.md`. Current summary: Skills `tokens_per_call` covers the three global roots (`~/.claude/skills/`, `~/.claude/scheduled-tasks/`, `~/.claude/plugins/`) plus project-local `.claude/skills/` directories discovered from cwds in the messages table. Only `Task`-dispatched subagent skills still show blank token counts.
 
 ## Verifying changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,6 @@ Component layout: `cli.py` (entry points) → `token_dashboard/scanner.py` (JSON
 
 ## Ideas that would genuinely help
 
-- Broadening the Skills catalog scan to cover project-local `.claude/skills/` directories (closes the known limitation).
 - A CSV or JSON export of any route.
 - A session-filter UI (currently everything is all-time or implicit-"recent").
 - A GitHub Actions workflow that runs the tests on push.

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -2,11 +2,9 @@
 
 None of these are blockers — the dashboard still gives you useful information. They're the rough edges you'll notice if you look hard.
 
-## Skills token counts are partial
+## Skills token counts are partial for subagent-dispatched skills
 
-The Skills route shows every skill Claude Code invoked, how many times, across how many sessions, and when. The **tokens-per-call** column is populated only for skills whose `SKILL.md` lives under `~/.claude/skills/`, `~/.claude/scheduled-tasks/`, or `~/.claude/plugins/`. Skills registered elsewhere (project-local `.claude/skills/`, or invocations that go through the `Task` tool with a skill-shaped `subagent_type`) show invocation counts but leave the token column blank.
-
-It's still a useful view — you can see which skills dominate your session time — just don't expect a complete per-skill token cost. PRs to broaden the catalog scan welcome.
+The Skills route shows every skill Claude Code invoked, how many times, across how many sessions, and when. The **tokens-per-call** column is populated for every skill whose `SKILL.md` lives under `~/.claude/skills/`, `~/.claude/scheduled-tasks/`, `~/.claude/plugins/`, or a project-local `.claude/skills/` directory discovered from the cwds in your session history. The one case that still leaves the token column blank is skills invoked through the `Task` tool with a skill-shaped `subagent_type` — those arrive without a resolvable slug on disk.
 
 ## Cost for Pro / Max / Max-20x users is shown as API-equivalent, not subscription value
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -3,7 +3,14 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from token_dashboard.skills import scan_catalog, _slugs_for
+from token_dashboard.skills import (
+    scan_catalog,
+    _slugs_for,
+    _project_skill_roots_from_cwds,
+    cached_catalog,
+    _cache,
+)
+from token_dashboard.db import connect, init_db
 
 
 def _write(p: Path, body: str) -> None:
@@ -68,6 +75,54 @@ class CatalogTests(unittest.TestCase):
         # No file written; lookup should return None (server surfaces as tokens_per_call: None)
         cat = scan_catalog([self.tmp / "skills"])
         self.assertNotIn("never-installed", cat)
+
+    def test_project_local_skill_slug(self):
+        _write(self.tmp / "proj" / ".claude" / "skills" / "my-skill" / "SKILL.md", "p" * 400)
+        cat = scan_catalog([self.tmp / "proj" / ".claude" / "skills"])
+        self.assertIn("my-skill", cat)
+        self.assertEqual(cat["my-skill"]["tokens"], 100)
+
+    def test_project_skill_roots_innermost_wins(self):
+        outer = self.tmp / "outer" / ".claude" / "skills"
+        inner = self.tmp / "outer" / "inner" / ".claude" / "skills"
+        outer.mkdir(parents=True)
+        inner.mkdir(parents=True)
+        roots = _project_skill_roots_from_cwds([str(self.tmp / "outer" / "inner" / "src")])
+        self.assertEqual(roots, [inner])
+
+    def test_project_skill_roots_dedupes_across_cwds(self):
+        root = self.tmp / "repo" / ".claude" / "skills"
+        root.mkdir(parents=True)
+        cwds = [
+            str(self.tmp / "repo" / "src"),
+            str(self.tmp / "repo" / "tests" / "unit"),
+        ]
+        roots = _project_skill_roots_from_cwds(cwds)
+        self.assertEqual(roots, [root])
+
+    def test_cached_catalog_includes_project_local_from_db(self):
+        # Reset the module-level cache so this test doesn't inherit neighbour state.
+        _cache["at"] = 0.0
+        _cache["data"] = {}
+        _cache["key"] = None
+
+        project = self.tmp / "myrepo"
+        _write(project / ".claude" / "skills" / "repo-skill" / "SKILL.md", "x" * 400)
+
+        db_path = self.tmp / "t.db"
+        init_db(db_path)
+        with connect(db_path) as c:
+            c.execute(
+                "INSERT INTO messages (uuid, session_id, project_slug, type, timestamp, cwd)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                ("u1", "s1", "myrepo", "user", "2026-04-23T00:00:00Z",
+                 str(project / "src")),
+            )
+            c.commit()
+
+        cat = cached_catalog(db_path)
+        self.assertIn("repo-skill", cat)
+        self.assertEqual(cat["repo-skill"]["tokens"], 100)
 
 
 if __name__ == "__main__":

--- a/token_dashboard/server.py
+++ b/token_dashboard/server.py
@@ -122,7 +122,7 @@ def build_handler(db_path: str, projects_dir: str):
                 return _send_json(self, daily_token_breakdown(db_path, since, until))
             if path == "/api/skills":
                 rows = skill_breakdown(db_path, since, until)
-                catalog = cached_catalog()
+                catalog = cached_catalog(db_path)
                 for r in rows:
                     info = catalog.get(r["skill"])
                     r["tokens_per_call"] = info["tokens"] if info else None

--- a/token_dashboard/skills.py
+++ b/token_dashboard/skills.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Iterable, Optional
 
 _DEFAULT_ROOTS = [
     Path.home() / ".claude" / "skills",
@@ -91,16 +91,50 @@ def scan_catalog(roots=None) -> Dict[str, dict]:
     return catalog
 
 
-_cache: dict = {"at": 0.0, "data": {}}
+def _project_skill_roots_from_cwds(cwds: Iterable[str]) -> list[Path]:
+    """Return the innermost `.claude/skills/` directory for each cwd.
+
+    Matches Claude Code's resolution rule: walk up from cwd and use the first
+    `.claude/skills/` found, so a nested repo uses its own skills, not a parent's.
+    """
+    roots: set[Path] = set()
+    for cwd in cwds:
+        if not cwd:
+            continue
+        p = Path(cwd)
+        for ancestor in (p, *p.parents):
+            candidate = ancestor / ".claude" / "skills"
+            if candidate.is_dir():
+                roots.add(candidate)
+                break
+    return sorted(roots)
+
+
+def _cwds_from_db(db_path) -> list[str]:
+    from .db import connect
+    with connect(db_path) as c:
+        return [r[0] for r in c.execute(
+            "SELECT DISTINCT cwd FROM messages WHERE cwd IS NOT NULL"
+        )]
+
+
+_cache: dict = {"at": 0.0, "data": {}, "key": None}
 _TTL_SECONDS = 60.0
 
 
-def cached_catalog() -> Dict[str, dict]:
-    """scan_catalog() with a simple in-process TTL cache."""
+def cached_catalog(db_path=None) -> Dict[str, dict]:
+    """scan_catalog() with a simple in-process TTL cache.
+
+    When `db_path` is provided, extra roots are derived from the distinct cwds
+    in `messages` so project-local `.claude/skills/` directories are included.
+    """
     now = time.time()
-    if now - _cache["at"] > _TTL_SECONDS:
-        _cache["data"] = scan_catalog()
+    key = str(db_path) if db_path else None
+    if now - _cache["at"] > _TTL_SECONDS or _cache["key"] != key:
+        extra = _project_skill_roots_from_cwds(_cwds_from_db(db_path)) if db_path else []
+        _cache["data"] = scan_catalog(_DEFAULT_ROOTS + extra)
         _cache["at"] = now
+        _cache["key"] = key
     return _cache["data"]
 
 


### PR DESCRIPTION
## Summary

Widen the Skills catalog scan to include project-local `.claude/skills/` directories, closing the first bullet of [`docs/KNOWN_LIMITATIONS.md`](docs/KNOWN_LIMITATIONS.md) and the first ideas-that-would-help item in [`CONTRIBUTING.md`](CONTRIBUTING.md).

Distinct cwds from the `messages` table are walked up to the nearest `.claude/skills/` directory (innermost wins, matching Claude Code's own resolution), then passed to `scan_catalog` alongside the three global roots. `cached_catalog` now takes an optional `db_path` and invalidates the cache when it changes.

After this, the **tokens-per-call** column is populated for every skill whose `SKILL.md` lives under `~/.claude/skills/`, `~/.claude/scheduled-tasks/`, `~/.claude/plugins/`, or any project-local `.claude/skills/` that has been used in a session. The one remaining gap is skills invoked through `Task` with a skill-shaped `subagent_type` — those arrive without a resolvable slug on disk.

## Changes

- `token_dashboard/skills.py` — new `_project_skill_roots_from_cwds()` + `_cwds_from_db()` helpers; `cached_catalog(db_path=None)` with cache-key invalidation.
- `token_dashboard/server.py` — one line: pass `db_path` into `cached_catalog`.
- `tests/test_skills.py` — 4 new unit + integration tests (71 → 75 green).
- `docs/KNOWN_LIMITATIONS.md` + `CONTRIBUTING.md` + `CLAUDE.md` — reflect the narrower remaining limitation.

Stdlib-only, no new dependencies.

## Test plan

- [x] `python3 -m unittest discover tests` — 75 green.
- [x] Live `/api/skills` on a machine with project-local `.claude/skills/` usage resolves `tokens_per_call` correctly; rows that were `null` before and whose `SKILL.md` lives in a scanned project now show a populated integer equal to file size // 4.
- [x] `cached_catalog` cache invalidates when called with a different `db_path`.