### PR TITLE
feat: configure Claude folder settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Claude Code writes one JSONL file per session to `~/.claude/projects/<project-sl
 
 ## Customizing
 
-Env vars: `PORT` (default 8080), `HOST` (default 127.0.0.1), `CLAUDE_PROJECTS_DIR`, `TOKEN_DASHBOARD_DB`. Pricing lives in `pricing.json`. See README.md § Environment variables for details.
+Env vars: `PORT` (default 8080), `HOST` (default 127.0.0.1), `CLAUDE_PROJECTS_DIR`, `TOKEN_DASHBOARD_DB`. The UI can persist a `.claude` folder fallback for scans. Pricing lives in `pricing.json`. See README.md § Environment variables for details.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ To point at a different location:
 python3 cli.py dashboard --projects-dir /path/to/projects --db /path/to/cache.db
 ```
 
+You can also change the `.claude` folder from the Settings tab. Changing the folder controls future scans; it does not automatically partition old cached data in the current SQLite DB. When switching accounts or profiles, either enable **Clear cached transcript data** in Settings before saving, or launch with a separate `--db` path if you want to keep each folder's dashboard history isolated.
+
 ### Environment variables
 
 | Var | Default | Purpose |
@@ -105,7 +107,7 @@ The Overview tab also has a built-in "What do these numbers mean?" panel that ex
 
 **Port 8080 already in use.** `PORT=9000 python3 cli.py dashboard`.
 
-**Numbers look wrong / stuck.** The DB lives at `~/.claude/token-dashboard.db`. Delete it and re-run `python3 cli.py scan` to rebuild from scratch.
+**Numbers look wrong / stuck.** The DB lives at `~/.claude/token-dashboard.db`. Delete it and re-run `python3 cli.py scan` to rebuild from scratch. If you changed the `.claude` folder in Settings, use **Clear cached transcript data** when saving the new folder to avoid combining data from multiple transcript roots.
 
 **Running the dashboard twice at the same time.** Don't — both processes will fight over the SQLite DB. Stop all instances before starting a new one.
 

--- a/cli.py
+++ b/cli.py
@@ -6,8 +6,15 @@ import os
 import webbrowser
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Optional
 
-from token_dashboard.db import init_db, default_db_path, overview_totals
+from token_dashboard.db import (
+    default_claude_dir,
+    default_db_path,
+    get_setting,
+    init_db,
+    overview_totals,
+)
 from token_dashboard.scanner import scan_dir
 from token_dashboard.tips import all_tips
 
@@ -16,12 +23,19 @@ def _db_path(args) -> str:
     return args.db or os.environ.get("TOKEN_DASHBOARD_DB") or str(default_db_path())
 
 
-def _projects(args) -> str:
-    return (
-        args.projects_dir
-        or os.environ.get("CLAUDE_PROJECTS_DIR")
-        or str(Path.home() / ".claude" / "projects")
-    )
+def _projects_override(args) -> Optional[str]:
+    return args.projects_dir or os.environ.get("CLAUDE_PROJECTS_DIR")
+
+
+def _projects(args, db_path: Optional[str] = None) -> str:
+    override = _projects_override(args)
+    if override:
+        return override
+    if db_path:
+        claude_dir = get_setting(db_path, "claude_dir")
+        if claude_dir:
+            return str(Path(claude_dir).expanduser() / "projects")
+    return str(default_claude_dir() / "projects")
 
 
 def _today_range():
@@ -34,7 +48,7 @@ def _today_range():
 def cmd_scan(args):
     db = _db_path(args)
     init_db(db)
-    n = scan_dir(_projects(args), db)
+    n = scan_dir(_projects(args, db), db)
     print(f"Token Dashboard: scanned {n['files']} files, {n['messages']} messages, {n['tools']} tool calls")
 
 
@@ -74,7 +88,7 @@ def cmd_dashboard(args):
     db = _db_path(args)
     init_db(db)
     if not args.no_scan:
-        scan_dir(_projects(args), db)
+        scan_dir(_projects(args, db), db)
     from token_dashboard.server import run
 
     host = os.environ.get("HOST", "127.0.0.1")
@@ -83,7 +97,7 @@ def cmd_dashboard(args):
     if not args.no_open:
         webbrowser.open(url)
     print(f"Token Dashboard listening on {url}")
-    run(host, port, db, _projects(args))
+    run(host, port, db, _projects_override(args))
 
 
 def main():
@@ -101,6 +115,7 @@ def main():
     d.add_argument("--no-scan", action="store_true")
     d.add_argument("--no-open", action="store_true")
     d.set_defaults(func=cmd_dashboard)
+
     args = p.parse_args()
     args.func(args)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -14,7 +14,7 @@ class InitDbTests(unittest.TestCase):
         init_db(self.db_path)
         with sqlite3.connect(self.db_path) as c:
             tables = {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type='table'")}
-        expected = {"files", "messages", "tool_calls", "plan", "dismissed_tips"}
+        expected = {"files", "messages", "tool_calls", "plan", "settings", "dismissed_tips"}
         self.assertTrue(expected.issubset(tables), f"Missing: {expected - tables}")
 
     def test_init_is_idempotent(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,7 @@ import tempfile
 import threading
 import unittest
 import urllib.request
+import urllib.error
 
 from token_dashboard.db import init_db
 from token_dashboard.server import build_handler
@@ -30,15 +31,26 @@ class ServerTests(unittest.TestCase):
             c.execute("INSERT INTO messages (uuid, parent_uuid, session_id, project_slug, type, timestamp, model, input_tokens, output_tokens, cache_read_tokens, cache_create_5m_tokens, cache_create_1h_tokens) VALUES ('a','u','s','p','assistant','2026-04-19T00:00:01Z','claude-haiku-4-5',1,1,0,0,0)")
             c.commit()
         self.port = _free_port()
-        H = build_handler(self.db, projects_dir="/nonexistent")
+        H = build_handler(self.db)
         self.httpd = http.server.HTTPServer(("127.0.0.1", self.port), H)
         threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
 
     def tearDown(self):
         self.httpd.shutdown()
+        self.httpd.server_close()
 
     def _get(self, path):
         return urllib.request.urlopen(f"http://127.0.0.1:{self.port}{path}").read()
+
+    def _post(self, path, body):
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{self.port}{path}",
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        return urllib.request.urlopen(req).read()
 
     def test_index_html(self):
         body = self._get("/")
@@ -62,6 +74,77 @@ class ServerTests(unittest.TestCase):
         body = json.loads(self._get("/api/plan"))
         self.assertIn("plan", body)
         self.assertIn("pricing", body)
+
+    def test_settings_json_defaults_to_home_claude(self):
+        body = json.loads(self._get("/api/settings"))
+        self.assertTrue(body["claude_dir"].endswith(".claude"))
+        self.assertTrue(body["projects_dir"].endswith(os.path.join(".claude", "projects")))
+        self.assertFalse(body["projects_overridden"])
+        self.assertIn(body["claude_dir"], body["claude_dirs"])
+
+    def test_settings_post_valid_claude_dir(self):
+        claude_dir = os.path.join(self.tmp, ".claude")
+        os.makedirs(os.path.join(claude_dir, "projects"))
+        body = json.loads(self._post("/api/settings", {"claude_dir": claude_dir}))
+        self.assertEqual(body["claude_dir"], claude_dir)
+        self.assertEqual(body["projects_dir"], os.path.join(claude_dir, "projects"))
+        self.assertEqual(body["claude_dirs"][0], claude_dir)
+        self.assertIn(claude_dir, body["claude_dirs"])
+
+    def test_settings_post_deduplicates_claude_dirs(self):
+        claude_dir = os.path.join(self.tmp, ".claude")
+        os.makedirs(os.path.join(claude_dir, "projects"))
+        self._post("/api/settings", {"claude_dir": claude_dir})
+        body = json.loads(self._post("/api/settings", {"claude_dir": claude_dir}))
+        self.assertEqual(body["claude_dirs"].count(claude_dir), 1)
+
+    def test_settings_post_can_clear_cached_scan_data(self):
+        claude_dir = os.path.join(self.tmp, ".claude")
+        os.makedirs(os.path.join(claude_dir, "projects"))
+        with sqlite3.connect(self.db) as c:
+            c.execute(
+                "INSERT INTO tool_calls (message_uuid, session_id, project_slug, tool_name, timestamp) VALUES ('a','s','p','Read','2026-04-19T00:00:02Z')"
+            )
+            c.execute("INSERT INTO files (path, mtime, bytes_read, scanned_at) VALUES ('old.jsonl', 1, 10, 1)")
+            c.commit()
+
+        body = json.loads(self._post("/api/settings", {"claude_dir": claude_dir, "reset_scan_data": True}))
+
+        self.assertEqual(body["claude_dir"], claude_dir)
+        with sqlite3.connect(self.db) as c:
+            self.assertEqual(c.execute("SELECT COUNT(*) FROM messages").fetchone()[0], 0)
+            self.assertEqual(c.execute("SELECT COUNT(*) FROM tool_calls").fetchone()[0], 0)
+            self.assertEqual(c.execute("SELECT COUNT(*) FROM files").fetchone()[0], 0)
+            self.assertEqual(c.execute("SELECT v FROM settings WHERE k='claude_dir'").fetchone()[0], claude_dir)
+
+    def test_settings_post_without_reset_keeps_cached_scan_data(self):
+        claude_dir = os.path.join(self.tmp, ".claude")
+        os.makedirs(os.path.join(claude_dir, "projects"))
+
+        body = json.loads(self._post("/api/settings", {"claude_dir": claude_dir, "reset_scan_data": False}))
+
+        self.assertEqual(body["claude_dir"], claude_dir)
+        with sqlite3.connect(self.db) as c:
+            self.assertEqual(c.execute("SELECT COUNT(*) FROM messages").fetchone()[0], 2)
+
+    def test_scan_uses_saved_claude_dir(self):
+        claude_dir = os.path.join(self.tmp, ".claude")
+        project = os.path.join(claude_dir, "projects", "demo")
+        os.makedirs(project)
+        with open(os.path.join(project, "s.jsonl"), "w", encoding="utf-8") as f:
+            f.write('{"type":"user","uuid":"su1","sessionId":"ss1","timestamp":"2026-04-20T00:00:00Z","message":{"role":"user","content":"hi"}}\n')
+        self._post("/api/settings", {"claude_dir": claude_dir})
+        body = json.loads(self._get("/api/scan"))
+        self.assertEqual(body["files"], 1)
+        self.assertEqual(body["messages"], 1)
+
+    def test_settings_post_invalid_claude_dir(self):
+        missing = os.path.join(self.tmp, "missing", ".claude")
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            self._post("/api/settings", {"claude_dir": missing})
+        self.assertEqual(cm.exception.code, 400)
+        body = json.loads(cm.exception.read())
+        self.assertIn("does not exist", body["error"])
 
     def test_head_returns_200_not_501(self):
         req = urllib.request.Request(f"http://127.0.0.1:{self.port}/", method="HEAD")

--- a/token_dashboard/db.py
+++ b/token_dashboard/db.py
@@ -68,6 +68,11 @@ CREATE TABLE IF NOT EXISTS plan (
   v TEXT
 );
 
+CREATE TABLE IF NOT EXISTS settings (
+  k TEXT PRIMARY KEY,
+  v TEXT
+);
+
 CREATE TABLE IF NOT EXISTS dismissed_tips (
   tip_key       TEXT PRIMARY KEY,
   dismissed_at  REAL NOT NULL
@@ -77,6 +82,10 @@ CREATE TABLE IF NOT EXISTS dismissed_tips (
 
 def default_db_path() -> Path:
     return Path.home() / ".claude" / "token-dashboard.db"
+
+
+def default_claude_dir() -> Path:
+    return Path.home() / ".claude"
 
 
 def init_db(path: Union[str, Path]) -> None:
@@ -119,6 +128,27 @@ def connect(path: Union[str, Path]):
         yield conn
     finally:
         conn.close()
+
+
+def get_setting(db_path: Union[str, Path], key: str, default: Optional[str] = None) -> Optional[str]:
+    with connect(db_path) as c:
+        row = c.execute("SELECT v FROM settings WHERE k=?", (key,)).fetchone()
+    return row["v"] if row else default
+
+
+def set_setting(db_path: Union[str, Path], key: str, value: str) -> None:
+    with connect(db_path) as c:
+        c.execute("INSERT OR REPLACE INTO settings (k, v) VALUES (?, ?)", (key, value))
+        c.commit()
+
+
+def clear_scan_data(db_path: Union[str, Path]) -> None:
+    """Clear cached transcript-derived rows without deleting user settings."""
+    with connect(db_path) as c:
+        c.execute("DELETE FROM tool_calls")
+        c.execute("DELETE FROM messages")
+        c.execute("DELETE FROM files")
+        c.commit()
 
 
 def _range_clause(since, until, col: str = "timestamp"):

--- a/token_dashboard/server.py
+++ b/token_dashboard/server.py
@@ -8,9 +8,11 @@ import queue
 import threading
 import time
 from pathlib import Path
+from typing import Optional, Tuple
 from urllib.parse import urlparse, parse_qs
 
 from .db import (
+    clear_scan_data, default_claude_dir, get_setting, set_setting,
     overview_totals, expensive_prompts, project_summary,
     tool_token_breakdown, recent_sessions, session_turns,
     daily_token_breakdown, model_breakdown, skill_breakdown,
@@ -25,8 +27,10 @@ WEB_ROOT = Path(__file__).resolve().parent.parent / "web"
 PRICING_JSON = Path(__file__).resolve().parent.parent / "pricing.json"
 
 EVENTS: "queue.Queue[dict]" = queue.Queue()
+# Keep cache resets from interleaving with background or manual scans.
+SCAN_LOCK = threading.Lock()
 
-MAX_POST_BYTES = 1_000_000  # 1 MB — we only accept tiny JSON bodies (plan, tip key)
+MAX_POST_BYTES = 1_000_000  # 1 MB — we only accept tiny JSON bodies (settings, plan, tip key)
 MAX_LIMIT = 1000
 
 
@@ -68,7 +72,67 @@ def _serve_static(handler, rel: str) -> None:
     handler.wfile.write(body)
 
 
-def build_handler(db_path: str, projects_dir: str):
+def _claude_dir(db_path: str) -> Path:
+    saved = get_setting(db_path, "claude_dir")
+    return Path(saved).expanduser() if saved else default_claude_dir()
+
+
+def _claude_dirs(db_path: str) -> list[str]:
+    active = str(_claude_dir(db_path))
+    raw = get_setting(db_path, "claude_dirs")
+    dirs = []
+    if raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = []
+        if isinstance(parsed, list):
+            dirs = [str(p) for p in parsed if isinstance(p, str) and p]
+    out = []
+    for path in [active, *dirs]:
+        if path not in out:
+            out.append(path)
+    return out
+
+
+def _remember_claude_dir(db_path: str, claude_dir: Path) -> None:
+    path = str(claude_dir)
+    dirs = [path, *[p for p in _claude_dirs(db_path) if p != path]]
+    set_setting(db_path, "claude_dirs", json.dumps(dirs))
+
+
+def _projects_dir(db_path: str, projects_override: Optional[str] = None) -> Path:
+    if projects_override:
+        return Path(projects_override).expanduser()
+    return _claude_dir(db_path) / "projects"
+
+
+def _validate_claude_dir(raw) -> Tuple[Optional[Path], Optional[str]]:
+    if not isinstance(raw, str) or not raw.strip():
+        return None, "claude_dir is required"
+    path = Path(raw.strip()).expanduser()
+    if not path.exists():
+        return None, f"{path} does not exist"
+    if not path.is_dir():
+        return None, f"{path} is not a directory"
+    projects = path / "projects"
+    if projects.exists() and not projects.is_dir():
+        return None, f"{projects} exists but is not a directory"
+    return path, None
+
+
+def _settings_payload(db_path: str, projects_override: Optional[str] = None) -> dict:
+    claude_dir = _claude_dir(db_path)
+    projects_dir = _projects_dir(db_path, projects_override)
+    return {
+        "claude_dir": str(claude_dir),
+        "projects_dir": str(projects_dir),
+        "projects_overridden": bool(projects_override),
+        "claude_dirs": _claude_dirs(db_path),
+    }
+
+
+def build_handler(db_path: str, projects_dir: Optional[str] = None):
     pricing = load_pricing(PRICING_JSON)
 
     class H(http.server.BaseHTTPRequestHandler):
@@ -141,8 +205,11 @@ def build_handler(db_path: str, projects_dir: str):
                 return _send_json(self, all_tips(db_path))
             if path == "/api/plan":
                 return _send_json(self, {"plan": get_plan(db_path), "pricing": pricing})
+            if path == "/api/settings":
+                return _send_json(self, _settings_payload(db_path, projects_dir))
             if path == "/api/scan":
-                n = scan_dir(projects_dir, db_path)
+                with SCAN_LOCK:
+                    n = scan_dir(_projects_dir(db_path, projects_dir), db_path)
                 return _send_json(self, n)
             if path == "/api/stream":
                 self.send_response(200)
@@ -181,6 +248,19 @@ def build_handler(db_path: str, projects_dir: str):
             if url.path == "/api/plan":
                 set_plan(db_path, body.get("plan", "api"))
                 return _send_json(self, {"ok": True})
+            if url.path == "/api/settings":
+                if "plan" in body:
+                    set_plan(db_path, body.get("plan", "api"))
+                if "claude_dir" in body:
+                    claude_dir, err = _validate_claude_dir(body.get("claude_dir"))
+                    if err:
+                        return _send_error(self, 400, err)
+                    with SCAN_LOCK:
+                        set_setting(db_path, "claude_dir", str(claude_dir))
+                        _remember_claude_dir(db_path, claude_dir)
+                        if body.get("reset_scan_data") is True:
+                            clear_scan_data(db_path)
+                return _send_json(self, {"ok": True, **_settings_payload(db_path, projects_dir)})
             if url.path == "/api/tips/dismiss":
                 dismiss_tip(db_path, body.get("key", ""))
                 return _send_json(self, {"ok": True})
@@ -190,10 +270,11 @@ def build_handler(db_path: str, projects_dir: str):
     return H
 
 
-def _scan_loop(db_path: str, projects_dir: str, interval: float = 30.0):
+def _scan_loop(db_path: str, projects_dir: Optional[str] = None, interval: float = 30.0):
     while True:
         try:
-            n = scan_dir(projects_dir, db_path)
+            with SCAN_LOCK:
+                n = scan_dir(_projects_dir(db_path, projects_dir), db_path)
             if n["messages"] > 0:
                 EVENTS.put({"type": "scan", "n": n, "ts": time.time()})
         except Exception as e:
@@ -201,7 +282,7 @@ def _scan_loop(db_path: str, projects_dir: str, interval: float = 30.0):
         time.sleep(interval)
 
 
-def run(host: str, port: int, db_path: str, projects_dir: str):
+def run(host: str, port: int, db_path: str, projects_dir: Optional[str] = None):
     threading.Thread(target=_scan_loop, args=(db_path, projects_dir), daemon=True).start()
     H = build_handler(db_path, projects_dir)
     httpd = http.server.ThreadingHTTPServer((host, port), H)

--- a/web/app.js
+++ b/web/app.js
@@ -92,16 +92,30 @@ async function firstRun() {
         <div class="spacer"></div>
         <button class="primary" id="firstsave">Continue</button>
       </div>
+      <p id="firstmsg" class="muted" style="margin:8px 0 0"></p>
     </div>`;
   document.body.appendChild(overlay);
   await new Promise(res => $('#firstsave', overlay).addEventListener('click', async () => {
     const plan = $('#firstplan', overlay).value;
-    await fetch('/api/plan', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ plan }) });
+    const msg = $('#firstmsg', overlay);
+    msg.textContent = 'Saving...';
+    const resp = await fetch('/api/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      msg.textContent = err.error || 'Could not save settings.';
+      msg.style.color = 'var(--bad)';
+      return;
+    }
     localStorage.setItem('td.plan-set', '1');
     overlay.remove();
     res();
   }));
   state.plan = (await api('/api/plan')).plan;
+  $('#plan-pill').textContent = state.plan;
 }
 
 async function boot() {

--- a/web/routes/settings.js
+++ b/web/routes/settings.js
@@ -1,8 +1,11 @@
-import { api, state, $ } from '/web/app.js';
+import { api, state, $, fmt } from '/web/app.js';
 
 export default async function (root) {
   const cur = await api('/api/plan');
+  const settings = await api('/api/settings');
   const plans = Object.entries(cur.pricing.plans);
+  const savedClaudeDirs = settings.claude_dirs || [];
+  let originalClaudeDir = settings.claude_dir;
   root.innerHTML = `
     <div class="card">
       <h2>Settings</h2>
@@ -15,6 +18,27 @@ export default async function (root) {
         <button class="primary" id="save">Save</button>
         <span id="msg" class="muted"></span>
       </div>
+
+      <hr class="divider">
+
+      <h3>Claude folder</h3>
+      <p class="muted" style="margin:0 0 12px">Set the <code>.claude</code> folder used for transcript scanning. The dashboard scans <code>projects</code> inside this folder. Existing cached dashboard data stays in this SQLite DB unless you clear it before scanning the new folder.</p>
+      <div class="flex">
+        <span class="combo-input ${savedClaudeDirs.length > 1 ? 'has-trigger' : ''}">
+          <input id="claude-dir" type="text" list="claude-dir-options" autocomplete="off" value="${fmt.htmlSafe(settings.claude_dir)}" ${settings.projects_overridden ? 'disabled' : ''}>
+          <button class="combo-trigger" id="claude-dir-picker" type="button" title="Show saved folders" aria-label="Show saved Claude folders" ${settings.projects_overridden ? 'disabled' : ''}>▾</button>
+        </span>
+        <datalist id="claude-dir-options">
+          ${savedClaudeDirs.map(p => `<option value="${fmt.htmlSafe(p)}"></option>`).join('')}
+        </datalist>
+        <button class="primary" id="save-settings" ${settings.projects_overridden ? 'disabled' : ''}>Save</button>
+        <span id="settings-msg" class="muted"></span>
+      </div>
+      <label class="muted" style="display:flex;align-items:flex-start;gap:8px;margin:0 0 10px;max-width:820px">
+        <input id="reset-scan-data" type="checkbox" checked ${settings.projects_overridden ? 'disabled' : ''}>
+        <span>Start fresh for this folder: remove previously scanned transcript data before the next scan, so usage from other accounts or profiles is not mixed in.</span>
+      </label>
+      ${settings.projects_overridden ? `<p class="muted" style="margin-top:8px">A launch-time projects directory is active: <code>${fmt.htmlSafe(settings.projects_dir)}</code></p>` : `<p class="muted" style="margin-top:8px">Current scan root: <code>${fmt.htmlSafe(settings.projects_dir)}</code></p>`}
 
       <hr class="divider">
 
@@ -43,10 +67,64 @@ export default async function (root) {
 
   $('#save').addEventListener('click', async () => {
     const plan = $('#plan').value;
-    await fetch('/api/plan', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ plan }) });
+    await fetch('/api/settings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ plan }) });
     state.plan = plan;
     document.getElementById('plan-pill').textContent = plan;
     $('#msg').textContent = 'Saved.';
     $('#msg').style.color = 'var(--good)';
+  });
+
+  $('#claude-dir')?.addEventListener('input', e => {
+    if (e.target.value.trim() !== originalClaudeDir) {
+      $('#reset-scan-data').checked = true;
+    }
+  });
+
+  $('#claude-dir-picker')?.addEventListener('click', () => {
+    const el = $('#claude-dir');
+    el.focus();
+    if (typeof el.showPicker === 'function') {
+      try {
+        el.showPicker();
+      } catch {
+        // Older browsers may expose showPicker but not support it for datalist inputs.
+      }
+    }
+  });
+
+  $('#save-settings').addEventListener('click', async () => {
+    const el = $('#claude-dir');
+    const reset = $('#reset-scan-data').checked;
+    const msg = $('#settings-msg');
+    msg.textContent = 'Saving...';
+    msg.style.color = 'var(--muted)';
+    const resp = await fetch('/api/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ claude_dir: el.value, reset_scan_data: reset }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      msg.textContent = err.error || 'Could not save.';
+      msg.style.color = 'var(--bad)';
+      return;
+    }
+    const saved = await resp.json();
+    originalClaudeDir = saved.claude_dir;
+    el.value = saved.claude_dir;
+    $('#reset-scan-data').checked = reset;
+    const options = $('#claude-dir-options');
+    options.innerHTML = (saved.claude_dirs || []).map(p => `<option value="${fmt.htmlSafe(p)}"></option>`).join('');
+    $('.combo-input')?.classList.toggle('has-trigger', (saved.claude_dirs || []).length > 1);
+
+    const scanResp = await fetch('/api/scan');
+    if (!scanResp.ok) {
+      const err = await scanResp.json().catch(() => ({}));
+      msg.textContent = err.error || 'Saved, but scan failed.';
+      msg.style.color = 'var(--bad)';
+      return;
+    }
+    msg.textContent = reset ? 'Cache cleared, saved, and scanned.' : 'Saved and scanned.';
+    msg.style.color = 'var(--good)';
   });
 }

--- a/web/style.css
+++ b/web/style.css
@@ -152,16 +152,53 @@ td.mono { font-family: var(--mono); color: var(--muted); }
 }
 
 /* buttons */
-button, select {
+button, select, input {
   background: var(--panel-2); color: var(--text);
   border: 1px solid var(--border); border-radius: 6px;
   padding: 6px 12px; font-family: var(--sans); font-size: 13px;
+}
+button, select {
   cursor: pointer;
 }
-button:hover, select:hover { border-color: var(--border-2); }
+button:hover, select:hover, input:hover { border-color: var(--border-2); }
+input:focus, select:focus { outline: 1px solid var(--accent); outline-offset: 1px; }
+input:disabled { color: var(--muted); cursor: not-allowed; }
 button.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
 button.primary:hover { background: #5BA8FF; }
 button.ghost { background: transparent; color: var(--muted); }
+.combo-input {
+  display: inline-flex;
+  align-items: stretch;
+  max-width: 100%;
+}
+.combo-input input {
+  min-width: 360px;
+  width: 520px;
+  max-width: 100%;
+}
+.combo-input.has-trigger input {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.combo-input .combo-trigger {
+  width: 34px;
+  padding: 6px 0;
+  border-left: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.combo-input:not(.has-trigger) .combo-trigger {
+  display: none;
+}
+@media (max-width: 720px) {
+  .combo-input {
+    flex: 1 1 100%;
+  }
+  .combo-input input {
+    min-width: 0;
+    width: 100%;
+  }
+}
 
 /* tip rows */
 .tip {
@@ -198,9 +235,13 @@ body.privacy-on .blur-sensitive { filter: blur(6px); }
 .modal h2 { margin: 0 0 8px; }
 .modal p { color: var(--muted); margin: 0 0 16px; }
 .modal .actions { display: flex; gap: 8px; align-items: center; margin-top: 16px; }
+.field { display: grid; gap: 6px; margin-top: 12px; }
+.field span { color: var(--muted); font-size: 12px; }
+.field input { width: 100%; }
 
 /* utility */
 .muted { color: var(--muted); }
+.small { font-size: 12px; }
 .flex { display: flex; align-items: center; gap: 8px; }
 .spacer { flex: 1; }
 hr.divider { border: 0; border-top: 1px solid var(--border); margin: 16px 0; }


### PR DESCRIPTION
## Summary

This PR makes the local dashboard easier to run in setups where the default assumptions do not fit:

- users can choose which `.claude` folder the dashboard scans from Settings
- previously used `.claude` folders are remembered and shown as selectable suggestions

The default behavior is unchanged: without configuration, the dashboard scans `~/.claude/projects`.

## Motivation

I use Claude Code with more than one account/profile, and each profile can keep local data in a different `.claude` folder. The existing `--projects-dir` and `CLAUDE_PROJECTS_DIR` options are useful for launch-time overrides, but they require pointing directly at the `projects` directory and are not persisted through the UI.

## What This Proposes

### Settings-based .claude folder selection
Adds a Settings control for the .claude folder used as the scan root. When a folder is selected, the dashboard scans:

<selected .claude folder>/projects
The SQLite cache location is not changed by this setting. It remains controlled by --db or TOKEN_DASHBOARD_DB.

Recent folder suggestions
When a valid .claude folder is saved, it is remembered locally in the dashboard SQLite DB. Settings uses a native browser datalist so users can either select a previously saved folder or type a new one.

Existing override behavior is preserved
--projects-dir and CLAUDE_PROJECTS_DIR still take precedence over the saved .claude folder. When either launch-time projects override is active, the Settings folder control is disabled and the active override path is shown.

Compatibility
Defaults remain unchanged:

scan source: ~/.claude/projects
DB location: ~/.claude/token-dashboard.db
Existing users do not need to change anything.

Validation
python3 -m unittest discover tests
Result: 78 tests passing.