### PR TITLE
chore(ci): run tests on push and PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run tests
+        run: python -m unittest discover tests


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `python3 -m unittest discover tests` on push and pull_request to `main`, across Python 3.8, 3.10, and 3.12.

Stdlib-only project, so no install step beyond `actions/setup-python@v5`. Matrix has `fail-fast: false` so a 3.8 break doesn't mask a 3.12 break (or vice versa).

Closes the "GitHub Actions workflow that runs the tests on push" item from `CONTRIBUTING.md`'s wishlist.
