### PR TITLE
feat: CSV and Markdown export for the Prompts route

### DIFF
--- a/web/export.js
+++ b/web/export.js
@@ -1,0 +1,60 @@
+// Drill export helpers — Markdown to clipboard, CSV to download.
+// Each caller builds a `sections` payload from the already-fetched drill
+// data. Shapes aren't validated here — the caller knows what it rendered.
+
+export function toMarkdown(title, sections) {
+  const out = [`# ${title}`, ''];
+  for (const s of sections) {
+    if (!s.rows?.length) continue;
+    out.push(`## ${s.heading}`, '');
+    out.push('| ' + s.columns.join(' | ') + ' |');
+    out.push('| ' + s.columns.map(() => '---').join(' | ') + ' |');
+    for (const r of s.rows) out.push('| ' + r.map(mdCell).join(' | ') + ' |');
+    out.push('');
+  }
+  return out.join('\n');
+}
+
+export function toCSV(sections) {
+  const lines = [];
+  for (const s of sections) {
+    if (!s.rows?.length) continue;
+    if (lines.length) lines.push('');
+    lines.push(`# ${s.heading}`);
+    lines.push(s.columns.map(csvCell).join(','));
+    for (const r of s.rows) lines.push(r.map(csvCell).join(','));
+  }
+  return lines.join('\n');
+}
+
+export async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function downloadBlob(filename, mime, text) {
+  const blob = new Blob([text], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function mdCell(v) {
+  if (v == null) return '';
+  return String(v).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function csvCell(v) {
+  if (v == null) return '';
+  const s = String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}

--- a/web/routes/prompts.js
+++ b/web/routes/prompts.js
@@ -1,4 +1,5 @@
 import { api, fmt } from '/web/app.js';
+import { toCSV, toMarkdown, copyToClipboard, downloadBlob } from '/web/export.js';
 
 const SORTS = [
   { key: 'tokens', label: 'Most tokens' },
@@ -35,6 +36,8 @@ export default async function (root) {
       <h2 style="margin:0;font-size:16px;letter-spacing:-0.01em">Prompts</h2>
       <div class="spacer"></div>
       ${sortTabs}
+      <button id="export-md" type="button" title="Copy this view to the clipboard as Markdown">Copy MD</button>
+      <button id="export-csv" type="button" title="Download this view as CSV">Download CSV</button>
     </div>
 
     <div class="card">
@@ -66,6 +69,35 @@ export default async function (root) {
 
   root.querySelectorAll('.range-tabs button').forEach(btn => {
     btn.addEventListener('click', () => writeSort(btn.dataset.sort));
+  });
+
+  const sections = [{
+    heading: `Prompts — ${sort.label.toLowerCase()}`,
+    columns: ['timestamp', 'prompt', 'model', 'billable_tokens', 'cache_read_tokens', 'estimated_cost_usd', 'session_id'],
+    rows: rows.map(r => [
+      r.timestamp,
+      r.prompt_text || '',
+      r.model || '',
+      r.billable_tokens,
+      r.cache_read_tokens,
+      r.estimated_cost_usd,
+      r.session_id,
+    ]),
+  }];
+
+  root.querySelector('#export-md').addEventListener('click', async () => {
+    const md = toMarkdown(`Prompts (${sort.label.toLowerCase()})`, sections);
+    const ok = await copyToClipboard(md);
+    const btn = root.querySelector('#export-md');
+    const original = btn.textContent;
+    btn.textContent = ok ? 'Copied!' : 'Copy failed';
+    setTimeout(() => { btn.textContent = original; }, 1500);
+  });
+
+  root.querySelector('#export-csv').addEventListener('click', () => {
+    const csv = toCSV(sections);
+    const stamp = new Date().toISOString().slice(0, 10);
+    downloadBlob(`prompts-${sort.key}-${stamp}.csv`, 'text/csv', csv);
   });
 
   root.querySelectorAll('#prompts tbody tr').forEach(tr => {


### PR DESCRIPTION
Closes upstream's "CSV or JSON export of any route" wishlist item from `CONTRIBUTING.md`.

## What this adds

- **`web/export.js`** (new, 60 lines) — four small helpers:
  - `toCSV(sections)` — RFC-4180-style escaping (quotes, commas, newlines)
  - `toMarkdown(title, sections)` — pipe-and-newline-safe GFM tables
  - `copyToClipboard(text)` — async, returns `true`/`false` so the caller can show feedback
  - `downloadBlob(filename, mime, text)` — anchor-based download with `URL.revokeObjectURL` cleanup
- **Prompts route header** — adds `Copy MD` and `Download CSV` buttons next to the existing sort tabs. Copy MD shows transient "Copied!" feedback. Download CSV exports the currently sorted set with the file name `prompts-<sort>-<YYYY-MM-DD>.csv`.

The helpers operate on a `sections` payload (`[{ heading, columns, rows }]`) so the same shape can be reused later for sessions / projects / skills exports without touching `export.js`.

## Why prompts first

Prompts are the route most useful to take into a spreadsheet — full text, model, tokens, cost, session. Other routes can follow in subsequent PRs once the helper shape is reviewed.

## Tests

JS-only utility code with manual smoke testing against the running dashboard:

```bash
python3 cli.py dashboard --no-open
# Open #/prompts → click Download CSV → opens with quoted prompt text
# Click Copy MD → "Copied!" feedback → paste into a markdown editor
```

The repo doesn't ship a JS test runner, so I didn't add one. Happy to add a Python integration test that hits `/api/prompts` and asserts the JSON shape `web/export.js` consumes, if there's a preferred shape.
