### PR TITLE
Skills: Track 'command' usage

### DIFF
--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -102,12 +102,22 @@ class SkillBreakdownTests(unittest.TestCase):
         init_db(self.db)
         with connect(self.db) as c:
             c.executescript("""
-            INSERT INTO messages (uuid, session_id, project_slug, type, timestamp)
+            INSERT INTO messages (uuid, session_id, project_slug, type, timestamp, attribution_skill)
             VALUES
-              ('u1','s1','pA','user','2026-04-10T00:00:00Z'),
-              ('a1','s1','pA','assistant','2026-04-10T00:00:01Z'),
-              ('u2','s2','pA','user','2026-04-11T00:00:00Z'),
-              ('a2','s2','pA','assistant','2026-04-11T00:00:01Z');
+              ('u1','s1','pA','user','2026-04-10T00:00:00Z',NULL),
+              ('a1','s1','pA','assistant','2026-04-10T00:00:01Z',NULL),
+              ('u2','s2','pA','user','2026-04-11T00:00:00Z',NULL),
+              ('a2','s2','pA','assistant','2026-04-11T00:00:01Z',NULL),
+              -- manual /command invocations: 'polish-email' in two distinct sessions,
+              -- 'name-conversation' in one. Multiple rows per session must collapse
+              -- to a single manual_session count via COUNT(DISTINCT session_id).
+              ('u3','s3','pA','user','2026-04-12T00:00:00Z','polish-email'),
+              ('a3','s3','pA','assistant','2026-04-12T00:00:01Z','polish-email'),
+              ('u4','s4','pA','user','2026-04-13T00:00:00Z','polish-email'),
+              ('u5','s5','pA','user','2026-04-14T00:00:00Z','name-conversation'),
+              -- 'brainstorming' also gets a manual session, to verify the COALESCE
+              -- merge of a skill that has BOTH tool invocations and manual sessions.
+              ('u6','s6','pA','user','2026-04-15T00:00:00Z','brainstorming');
 
             INSERT INTO tool_calls (message_uuid, session_id, project_slug, tool_name, target, result_tokens, timestamp, is_error)
             VALUES
@@ -123,18 +133,46 @@ class SkillBreakdownTests(unittest.TestCase):
     def test_groups_by_skill(self):
         rows = skill_breakdown(self.db)
         by_name = {r["skill"]: r for r in rows}
-        self.assertEqual(by_name["brainstorming"]["invocations"], 2)
-        self.assertEqual(by_name["brainstorming"]["sessions"], 1)
-        self.assertEqual(by_name["create-skill"]["invocations"], 1)
+        # brainstorming: both tool invocations AND a manual session — exercises
+        # the COALESCE merge branch of the UNION.
+        self.assertEqual(by_name["brainstorming"]["tool_invocations"], 2)
+        self.assertEqual(by_name["brainstorming"]["manual_sessions"], 1)
+        self.assertEqual(by_name["create-skill"]["tool_invocations"], 1)
+        self.assertEqual(by_name["create-skill"]["manual_sessions"], 0)
 
-    def test_orders_by_invocations(self):
+    def test_manual_only_skill_appears(self):
+        # name-conversation has no Skill tool calls — only an attribution_skill
+        # entry. This exercises the second UNION arm (manual_inv LEFT JOIN
+        # tool_inv WHERE t.skill IS NULL).
         rows = skill_breakdown(self.db)
-        self.assertEqual(rows[0]["skill"], "brainstorming")
+        by_name = {r["skill"]: r for r in rows}
+        self.assertIn("name-conversation", by_name)
+        self.assertEqual(by_name["name-conversation"]["manual_sessions"], 1)
+        self.assertEqual(by_name["name-conversation"]["tool_invocations"], 0)
+
+    def test_manual_sessions_distinct(self):
+        # polish-email has three attribution rows across two distinct sessions
+        # (s3 has two rows, s4 has one) — must collapse to 2 via DISTINCT.
+        rows = skill_breakdown(self.db)
+        by_name = {r["skill"]: r for r in rows}
+        self.assertEqual(by_name["polish-email"]["manual_sessions"], 2)
+        self.assertEqual(by_name["polish-email"]["tool_invocations"], 0)
+
+    def test_orders_by_combined_total(self):
+        # brainstorming (2 tool + 1 manual = 3) ranks above polish-email
+        # (0 tool + 2 manual = 2), proving ordering uses the sum, not just one.
+        rows = skill_breakdown(self.db)
+        names = [r["skill"] for r in rows]
+        self.assertEqual(names[0], "brainstorming")
+        self.assertLess(names.index("brainstorming"), names.index("polish-email"))
 
     def test_respects_since(self):
-        rows = skill_breakdown(self.db, since="2026-04-11T00:00:00Z")
-        names = [r["skill"] for r in rows]
-        self.assertEqual(names, ["create-skill"])
+        rows = skill_breakdown(self.db, since="2026-04-12T00:00:00Z")
+        names = {r["skill"] for r in rows}
+        # 2026-04-10 brainstorming tool calls and 2026-04-11 create-skill drop out.
+        self.assertNotIn("create-skill", names)
+        self.assertIn("polish-email", names)
+        self.assertIn("name-conversation", names)
 
 
 class ProjectNameTests(unittest.TestCase):

--- a/token_dashboard/db.py
+++ b/token_dashboard/db.py
@@ -40,7 +40,8 @@ CREATE TABLE IF NOT EXISTS messages (
   cache_create_1h_tokens  INTEGER NOT NULL DEFAULT 0,
   prompt_text             TEXT,
   prompt_chars            INTEGER,
-  tool_calls_json         TEXT
+  tool_calls_json         TEXT,
+  attribution_skill       TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_messages_session   ON messages(session_id);
 CREATE INDEX IF NOT EXISTS idx_messages_project   ON messages(project_slug);
@@ -84,6 +85,7 @@ def init_db(path: Union[str, Path]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(path) as c:
         _migrate_add_message_id(c)
+        _migrate_add_attribution_skill(c)
         c.executescript(SCHEMA)
 
 
@@ -104,6 +106,30 @@ def _migrate_add_message_id(conn) -> None:
     if "message_id" in cols:
         return
     conn.execute("ALTER TABLE messages ADD COLUMN message_id TEXT")
+    conn.execute("DELETE FROM messages")
+    conn.execute("DELETE FROM tool_calls")
+    conn.execute("DELETE FROM files")
+    conn.commit()
+
+
+def _migrate_add_attribution_skill(conn) -> None:
+    """Add messages.attribution_skill to track slash-command invocations.
+
+    Why: attributionSkill in JSONL records shows which slash command (or skill)
+    was active for a message, but was never stored. Without it the skills view
+    only counts explicit Skill tool calls and misses all /command invocations.
+    How to apply: clears messages/tool_calls/files so the next scan replays
+    all JSONLs and populates the new column for every row.
+    """
+    has_table = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages'"
+    ).fetchone()
+    if not has_table:
+        return
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(messages)")}
+    if "attribution_skill" in cols:
+        return
+    conn.execute("ALTER TABLE messages ADD COLUMN attribution_skill TEXT")
     conn.execute("DELETE FROM messages")
     conn.execute("DELETE FROM tool_calls")
     conn.execute("DELETE FROM files")
@@ -331,29 +357,57 @@ def daily_token_breakdown(db_path, since=None, until=None) -> list:
 
 
 def skill_breakdown(db_path, since=None, until=None) -> list:
-    """Per-skill invocation counts, distinct sessions, last-used timestamp.
+    """Per-skill invocation counts split into two types:
 
-    Token attribution per skill is not included: in Claude Code, a Skill's
-    content is loaded via a system-reminder on the next turn, not as the
-    tool_result body — so `result_tokens` on _tool_result rows reflects the
-    activation ack (tiny), not the skill definition (which is what actually
-    fills context). A future schema change (storing tool_use_id on the
-    invocation row) could enable precise attribution; for now we only expose
-    the reliable counts.
+    - manual_sessions: distinct sessions where the user ran /command-name,
+      tracked via the attributionSkill field on messages.
+    - tool_invocations: times Claude explicitly called the Skill tool
+      mid-conversation, tracked via tool_calls rows.
+
+    Both are merged into a single row per skill, ordered by combined total.
     """
-    rng, args = _range_clause(since, until)
+    rng_tc, args_tc = _range_clause(since, until)
+    rng_ms, args_ms = _range_clause(since, until)
+    # Simulate FULL OUTER JOIN via UNION (FULL OUTER JOIN requires SQLite ≥ 3.39).
     sql = f"""
-      SELECT target AS skill,
-             COUNT(*) AS invocations,
-             COUNT(DISTINCT session_id) AS sessions,
-             MAX(timestamp) AS last_used
-        FROM tool_calls
-       WHERE tool_name = 'Skill' AND target IS NOT NULL AND target != '' {rng}
-       GROUP BY target
-       ORDER BY invocations DESC
+      WITH tool_inv AS (
+        SELECT target AS skill,
+               COUNT(*) AS tool_invocations,
+               MAX(timestamp) AS last_used_tool
+          FROM tool_calls tc
+         WHERE tool_name = 'Skill' AND target IS NOT NULL AND target != '' {rng_tc}
+           AND EXISTS (SELECT 1 FROM messages m
+                       WHERE m.uuid = tc.message_uuid AND m.type = 'assistant')
+         GROUP BY target
+      ),
+      manual_inv AS (
+        SELECT attribution_skill AS skill,
+               COUNT(DISTINCT session_id) AS manual_sessions,
+               MAX(timestamp) AS last_used_manual
+          FROM messages
+         WHERE attribution_skill IS NOT NULL AND attribution_skill != '' {rng_ms}
+         GROUP BY attribution_skill
+      )
+      SELECT skill, manual_sessions, tool_invocations, last_used FROM (
+        SELECT
+          COALESCE(t.skill, m.skill) AS skill,
+          COALESCE(m.manual_sessions, 0)   AS manual_sessions,
+          COALESCE(t.tool_invocations, 0)  AS tool_invocations,
+          MAX(COALESCE(t.last_used_tool, ''), COALESCE(m.last_used_manual, '')) AS last_used
+        FROM tool_inv t LEFT JOIN manual_inv m ON t.skill = m.skill
+        UNION
+        SELECT
+          m.skill,
+          m.manual_sessions,
+          0,
+          m.last_used_manual
+        FROM manual_inv m LEFT JOIN tool_inv t ON m.skill = t.skill
+        WHERE t.skill IS NULL
+      )
+      ORDER BY (manual_sessions + tool_invocations) DESC
     """
     with connect(db_path) as c:
-        return [dict(r) for r in c.execute(sql, args)]
+        return [dict(r) for r in c.execute(sql, args_tc + args_ms)]
 
 
 def model_breakdown(db_path, since=None, until=None) -> list:

--- a/token_dashboard/scanner.py
+++ b/token_dashboard/scanner.py
@@ -14,12 +14,12 @@ INSERT OR REPLACE INTO messages (
   uuid, parent_uuid, session_id, project_slug, cwd, git_branch, cc_version, entrypoint,
   type, is_sidechain, agent_id, timestamp, model, stop_reason, prompt_id, message_id,
   input_tokens, output_tokens, cache_read_tokens, cache_create_5m_tokens, cache_create_1h_tokens,
-  prompt_text, prompt_chars, tool_calls_json
+  prompt_text, prompt_chars, tool_calls_json, attribution_skill
 ) VALUES (
   :uuid, :parent_uuid, :session_id, :project_slug, :cwd, :git_branch, :cc_version, :entrypoint,
   :type, :is_sidechain, :agent_id, :timestamp, :model, :stop_reason, :prompt_id, :message_id,
   :input_tokens, :output_tokens, :cache_read_tokens, :cache_create_5m_tokens, :cache_create_1h_tokens,
-  :prompt_text, :prompt_chars, :tool_calls_json
+  :prompt_text, :prompt_chars, :tool_calls_json, :attribution_skill
 )
 """
 
@@ -143,9 +143,10 @@ def parse_record(rec: dict, project_slug: str) -> Tuple[dict, List[dict]]:
         "stop_reason":  msg_obj.get("stop_reason"),
         "prompt_id":    rec.get("promptId"),
         "message_id":   msg_obj.get("id"),
-        "prompt_text":  text,
-        "prompt_chars": chars,
-        "tool_calls_json": None,
+        "prompt_text":       text,
+        "prompt_chars":      chars,
+        "tool_calls_json":   None,
+        "attribution_skill": rec.get("attributionSkill") or None,
         **_usage(rec),
     }
     tools = _extract_tools(rec)

--- a/web/routes/skills.js
+++ b/web/routes/skills.js
@@ -1,5 +1,5 @@
 import { api, fmt } from '/web/app.js';
-import { barChart } from '/web/charts.js';
+import { groupedBarChart } from '/web/charts.js';
 
 const RANGES = [
   { key: '7d',  label: '7d',  days: 7 },
@@ -31,8 +31,8 @@ export default async function (root) {
   const url = '/api/skills' + (since ? '?since=' + encodeURIComponent(since) : '');
   const skills = await api(url);
 
-  const totalInvocations = skills.reduce((s, r) => s + r.invocations, 0);
-  const totalSessions = new Set(); // not exact — we'd need another query; skip.
+  const totalManual = skills.reduce((s, r) => s + r.manual_sessions, 0);
+  const totalTool   = skills.reduce((s, r) => s + r.tool_invocations, 0);
 
   const rangeTabs = `
     <div class="range-tabs" role="tablist">
@@ -41,42 +41,47 @@ export default async function (root) {
 
   root.innerHTML = `
     <div class="flex" style="margin-bottom:14px">
-      <h2 style="margin:0;font-size:16px;letter-spacing:-0.01em">Skills</h2>
+      <h2 style="margin:0;font-size:16px;letter-spacing:-0.01em">Skills &amp; Commands</h2>
       <span class="muted" style="font-size:12px">${range.days ? `last ${range.days} days` : 'all time'}</span>
       <div class="spacer"></div>
       ${rangeTabs}
     </div>
 
-    <div class="row cols-2">
-      <div class="card kpi"><div class="label">Unique skills used</div><div class="value">${fmt.int(skills.length)}</div></div>
-      <div class="card kpi"><div class="label">Total invocations</div><div class="value">${fmt.int(totalInvocations)}</div></div>
+    <div class="row cols-3">
+      <div class="card kpi"><div class="label">Unique skills / commands</div><div class="value">${fmt.int(skills.length)}</div></div>
+      <div class="card kpi"><div class="label">You ran <span class="muted" style="font-weight:400;font-size:11px">(slash commands)</span></div><div class="value">${fmt.int(totalManual)}</div></div>
+      <div class="card kpi"><div class="label">Claude invoked <span class="muted" style="font-weight:400;font-size:11px">(Skill tool)</span></div><div class="value">${fmt.int(totalTool)}</div></div>
     </div>
 
     <div class="card" style="margin-top:16px">
-      <h3>Top skills (by invocations)</h3>
+      <h3>Top skills &amp; commands</h3>
       <div id="ch-skills" style="height:320px"></div>
     </div>
 
     <div class="card" style="margin-top:16px">
-      <h3>All skills</h3>
-      <p class="muted" style="margin:-4px 0 14px;font-size:12px">"Tokens per call" is the size of the skill's <code>SKILL.md</code> file — what Claude Code loads into context each time the skill is invoked.</p>
+      <h3>All skills &amp; commands</h3>
+      <p class="muted" style="margin:-4px 0 14px;font-size:12px">
+        <strong>You ran</strong> = sessions where you typed the slash command directly.
+        <strong>Claude invoked</strong> = times Claude called the Skill tool mid-conversation.
+        <strong>Skill tokens</strong> = size of the skill's <code>SKILL.md</code> loaded into context per invocation (slash commands show — as their file is not a registered skill).
+      </p>
       <table>
         <thead><tr>
-          <th>skill</th>
-          <th class="num">invocations</th>
-          <th class="num">tokens per call</th>
-          <th class="num">sessions</th>
+          <th>skill / command</th>
+          <th class="num">you ran</th>
+          <th class="num">claude invoked</th>
+          <th class="num">skill tokens</th>
           <th>last used</th>
         </tr></thead>
         <tbody>
           ${skills.map(s => `
             <tr>
               <td><span class="badge">${fmt.htmlSafe(s.skill)}</span></td>
-              <td class="num">${fmt.int(s.invocations)}</td>
+              <td class="num">${s.manual_sessions  ? fmt.int(s.manual_sessions)  : '<span class="muted">—</span>'}</td>
+              <td class="num">${s.tool_invocations ? fmt.int(s.tool_invocations) : '<span class="muted">—</span>'}</td>
               <td class="num">${s.tokens_per_call == null ? '<span class="muted">—</span>' : fmt.int(s.tokens_per_call)}</td>
-              <td class="num">${fmt.int(s.sessions)}</td>
               <td class="mono">${fmt.ts(s.last_used)}</td>
-            </tr>`).join('') || '<tr><td colspan="5" class="muted">no skills invoked in this range</td></tr>'}
+            </tr>`).join('') || '<tr><td colspan="5" class="muted">no skills used in this range</td></tr>'}
         </tbody>
       </table>
     </div>
@@ -87,9 +92,11 @@ export default async function (root) {
   });
 
   const top = skills.slice(0, 12);
-  barChart(document.getElementById('ch-skills'), {
+  groupedBarChart(document.getElementById('ch-skills'), {
     categories: top.map(t => t.skill.length > 26 ? t.skill.slice(0, 25) + '…' : t.skill),
-    values: top.map(t => t.invocations),
-    color: '#3FB68B',
+    series: [
+      { name: 'You ran',        values: top.map(t => t.manual_sessions),  color: '#3FB68B' },
+      { name: 'Claude invoked', values: top.map(t => t.tool_invocations), color: '#7B61FF' },
+    ],
   });
 }


### PR DESCRIPTION
The Skills tab now also tracks custom and plugin-installed slash commands you run directly, not just times Claude invoked the Skill tool mid-conversation. 

Built-in Claude Code commands (/help, /clear, /model, etc.) are not tracked — Claude Code doesn't tag them as skill invocations. 

The page is renamed to Skills & Commands, gains two KPIs ("You ran" / "Claude invoked"), and the table splits the old invocations column into the same two. 

On first launch after upgrade, the dashboard re-scans all JSONLs to backfill historical attribution.